### PR TITLE
Specify the php_codesniffer version as `2.*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For the purposes of this document, we're installing PHP CodeSniffer on a project
 From the integrated terminal within Visual Studio Code, enter the following command:
 
 ```
-$ composer require "squizlabs/php_codesniffer=*"
+$ composer require "squizlabs/php_codesniffer=2.*"
 ```
 
 This will create `composer.json`, tell it where to locate the PHP CodeSniffer, and install it in a `vendor` directory. Once this is done, we need the WordPress Coding Standard ruleset.


### PR DESCRIPTION
The WordPress Coding Standards are currently not compatible with the PHPCS 3 release. Now that PHPCS 3 has been released we need to explicitly use version 2.

See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/718

I'm not sure if an explanation of this change is necessary within the text of the article so I've left it as is.